### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+* &lt;what this PR does&gt;
+* &lt;why this is needed&gt;
+* &lt;context for anyone reading this in 6 months or years&gt;
+
+Review:
+
+* [ ] code is understandable
+* [ ] code is covered by specs
+* [ ] no performance issues found
+* [ ] no security issues found
+
+fixes/see #&lt;issue-no&gt; (use _see_ if issue requires QA and should not be closed automatically)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,5 +8,6 @@ Review:
 * [ ] code is covered by specs
 * [ ] no performance issues found
 * [ ] no security issues found
+* [ ] when UI is affected: checked out in browser and looks and works as expected
 
 fixes/see #&lt;issue-no&gt; (use _see_ if issue requires QA and should not be closed automatically)


### PR DESCRIPTION
As discussed in the retro today. The main point is to remind devs in sprints to not automatically close issues via PRs if the issue needs QA. Also added a few ponts from our [Code review guide](https://www.notion.so/cobotme/Guidelines-for-Code-Reviews-47bb3c9b07f64156a2eb8834479454c5).